### PR TITLE
Check if front_matter is a dictionary before processing it

### DIFF
--- a/md-to-bundle.py
+++ b/md-to-bundle.py
@@ -57,6 +57,10 @@ def md_to_bundle(md_path, add_tag, tag, export_dir):
     content = read_file(md_path)
     front_matter, end_index = parse_front_matter(content)
     basename = os.path.basename(md_path)
+    
+    # Ensure front_matter is a dictionary
+    if not isinstance(front_matter, dict):
+        front_matter = {}
 
     # Dealing with tags
     if front_matter is not None:


### PR DESCRIPTION
First off, thank you for making this! It works amazing! However, when I tried to run it, I was getting this error:
```bash
File "md-to-bundle.py", line 63, in md_to_bundle
    tags = front_matter.get('tags', [])
AttributeError: 'str' object has no attribute 'get'
```

So I added a check to make sure front_matter is a dictionary. If not, it will convert it to an empty dictionary. There may be problems I haven't of with this, but for me, at least, it gets the script to actually run.