### PR TITLE
Fix error if `tags` frontmatter value is `None`

### DIFF
--- a/md-to-bundle.py
+++ b/md-to-bundle.py
@@ -71,8 +71,7 @@ def md_to_bundle(md_path, add_tag, tag, export_dir):
     if add_tag and len(tag) > 0:
         tags.append(tag)
 
-
-    if len(tags) > 0:
+    if tags is not None and len(tags) > 0:
         fm_tags_str = '# #'.join(tags)
         # insert tag in end of file
         content = content + '\n#{}#'.format(fm_tags_str)


### PR DESCRIPTION
An Obsidian note's `tags` frontmatter can be interpreted as `None` when running this script.

This PR fices this error by checking forthe `tags` value is not `None` before checking the `len()` of the tags.

See example of Obsidian note frontmatter with an empty `tags` value:

<img width="316" alt="image" src="https://github.com/devinhurry/markdown-to-textbundle-for-bear/assets/3147296/5d2556ee-be66-49ae-b02a-2ab1a08583b4">
